### PR TITLE
add prison yard with heptagon-floor according to map

### DIFF
--- a/Assets/Prefabs/heptagon_prison_yard_with_corridor.prefab
+++ b/Assets/Prefabs/heptagon_prison_yard_with_corridor.prefab
@@ -1,0 +1,59 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &5790805586400718443
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: d3f5531c07bacf21aabbd9cc824f13a4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -68.657906
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3f5531c07bacf21aabbd9cc824f13a4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 22.140856
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3f5531c07bacf21aabbd9cc824f13a4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 55.04772
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3f5531c07bacf21aabbd9cc824f13a4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3f5531c07bacf21aabbd9cc824f13a4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3f5531c07bacf21aabbd9cc824f13a4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3f5531c07bacf21aabbd9cc824f13a4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3f5531c07bacf21aabbd9cc824f13a4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3f5531c07bacf21aabbd9cc824f13a4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: d3f5531c07bacf21aabbd9cc824f13a4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: d3f5531c07bacf21aabbd9cc824f13a4, type: 3}
+      propertyPath: m_Name
+      value: heptagon_prison_yard_with_corridor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d3f5531c07bacf21aabbd9cc824f13a4, type: 3}

--- a/Assets/Prefabs/heptagon_prison_yard_with_corridor.prefab.meta
+++ b/Assets/Prefabs/heptagon_prison_yard_with_corridor.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dca7eca5597fbbd43bc9d79b51eb16e6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/heptagon_prison_yard_with_corridor.fbx
+++ b/Assets/heptagon_prison_yard_with_corridor.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd0d5f2275fc628ad90aeba67f09f810b7cf295a4cafb7d7153c0ffd00b4f000
+size 26076

--- a/Assets/heptagon_prison_yard_with_corridor.fbx.meta
+++ b/Assets/heptagon_prison_yard_with_corridor.fbx.meta
@@ -1,0 +1,110 @@
+fileFormatVersion: 2
+guid: d3f5531c07bacf21aabbd9cc824f13a4
+ModelImporter:
+  serializedVersion: 24200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
+    motionNodeName: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importPhysicalCameras: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    generateMeshLods: 0
+    meshLodGenerationFlags: 0
+    maximumMeshLod: -1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Habe in diesem Pull Request den Gefängnis-Hof mit den Durchgängen aus dem Plan eingeführt. Habe einmal das Modell hochgeladen, sowie ein Prefab, welches wir immer wieder verwenden können. Falls bei Bedarf noch Fenster/Türen eingefügt werden sollen in das Mesh, kann das jederzeit geschehen, und das entsprechende Asset kann durch das neue Blender-Modell ersetzt werden. Die Außenwand-Länge jeder Seite beträgt ~6m, was Ideal für die Modellierung der anderen Räumlichkeiten ist. Bitte aber gerne einmal das Prefab als Review in eine Testscene ziehen und schauen, ob soweit vorhanden ist.