### PR TITLE
fix outside materials of entrance_with_visitor_rooms.prefab

### DIFF
--- a/Assets/Prefabs/heptagon_sides/entrance_with_visitor_rooms.prefab
+++ b/Assets/Prefabs/heptagon_sides/entrance_with_visitor_rooms.prefab
@@ -2038,6 +2038,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4157103995261680203, guid: 8faf3b8d1ae61b04b869c7d07a99f1db, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
+    - target: {fileID: 4157103995261680203, guid: 8faf3b8d1ae61b04b869c7d07a99f1db, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
       objectReference: {fileID: 2100000, guid: dff06ded3acfb4e4c901b78b0fdfda8b, type: 2}
@@ -4142,6 +4146,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
+    - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
       objectReference: {fileID: 2100000, guid: dff06ded3acfb4e4c901b78b0fdfda8b, type: 2}
@@ -5034,6 +5042,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
+    - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
       objectReference: {fileID: 2100000, guid: dff06ded3acfb4e4c901b78b0fdfda8b, type: 2}
@@ -5293,6 +5305,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
@@ -5944,7 +5960,7 @@ PrefabInstance:
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
-      objectReference: {fileID: 2100000, guid: dff06ded3acfb4e4c901b78b0fdfda8b, type: 2}
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -6406,7 +6422,7 @@ PrefabInstance:
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
-      objectReference: {fileID: 2100000, guid: dff06ded3acfb4e4c901b78b0fdfda8b, type: 2}
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -6734,6 +6750,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
+    - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
       objectReference: {fileID: 2100000, guid: dff06ded3acfb4e4c901b78b0fdfda8b, type: 2}
@@ -6818,9 +6838,17 @@ PrefabInstance:
     m_TransformParent: {fileID: 2595888060853566893}
     m_Modifications:
     - target: {fileID: 1158315993814442110, guid: ba561473287cfa045bae6fe3f8604ece, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
+    - target: {fileID: 1158315993814442110, guid: ba561473287cfa045bae6fe3f8604ece, type: 3}
       propertyPath: 'm_Materials.Array.data[2]'
       value: 
       objectReference: {fileID: 2100000, guid: dff06ded3acfb4e4c901b78b0fdfda8b, type: 2}
+    - target: {fileID: 4611164815108111335, guid: ba561473287cfa045bae6fe3f8604ece, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
     - target: {fileID: 4611164815108111335, guid: ba561473287cfa045bae6fe3f8604ece, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
@@ -7179,6 +7207,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
@@ -8053,6 +8085,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
@@ -9840,6 +9876,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
+    - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
       objectReference: {fileID: 2100000, guid: dff06ded3acfb4e4c901b78b0fdfda8b, type: 2}
@@ -10040,7 +10080,7 @@ PrefabInstance:
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
-      objectReference: {fileID: 2100000, guid: dff06ded3acfb4e4c901b78b0fdfda8b, type: 2}
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -11370,6 +11410,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
+    - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
       objectReference: {fileID: 2100000, guid: dff06ded3acfb4e4c901b78b0fdfda8b, type: 2}
@@ -11629,6 +11673,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
@@ -11896,7 +11944,7 @@ PrefabInstance:
     - target: {fileID: 6558207639728429531, guid: 274deb2904e9ba940bce69f585e1ffe8, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 
-      objectReference: {fileID: 2100000, guid: dff06ded3acfb4e4c901b78b0fdfda8b, type: 2}
+      objectReference: {fileID: 2100000, guid: 0da42f37180c9924fb6cb0e71b03278e, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []


### PR DESCRIPTION
This pull request adds a new folder structure and several material assets for car models in the Unity project. The main changes are the creation of the `Fab_content` asset folder and the addition of multiple car-related material files, each with their associated Unity metadata files.

**Asset Structure Creation:**

* Added new folder `Assets/Fab_content` and subfolders for organizing car assets, including `Cars`, `Art`, and `Materials`. [[1]](diffhunk://#diff-e96f90fc28a2bf2e62f9c5bb1757509dc6a45509a586c748358293b1de43d7c8R1-R8) [[2]](diffhunk://#diff-24bec3882c20c101830134d8657f744c5d0fcc19dacdafde5af2e4922277a539R1-R8) [[3]](diffhunk://#diff-cce47fe075a61765bb37cb287c412a656e4bd1c0bce4c805d3983bd685cbc57cR1-R8) [[4]](diffhunk://#diff-0016a260e66f27fbfb3cf85d60d0e9c92d308f2f73d5897d7d6a24e33b072f29R1-R8)

**Material Assets for Cars:**

* Added material files for car models: `Anthrazit.mat`, `Asphalt.mat`, `Blue.mat`, `Car_Color_Mat.mat`, and `Car_Glass_Mat.mat`, each configured with relevant shaders, colors, and properties for rendering in Unity. [[1]](diffhunk://#diff-a4753d4dd12dba2330059ec66f444e28aa399185cb7602c6df8acc8fa66e4dd2R1-R139) [[2]](diffhunk://#diff-97875f46a780184fe0f11bb3b1476e608817d7cf837fde90f4e5a5f646da3c25R1-R139) [[3]](diffhunk://#diff-73aeff663874d0bc38fc7fe879aa1c451f0283cd544ec80a44b1eeba6330202fR1-R139) [[4]](diffhunk://#diff-6522ad0405ab1b0413be4d98f6550fdbf2f4a37cb5bc4c0254eac1436136b985R1-R139) [[5]](diffhunk://#diff-e0cfe9e453dd95e7497ad7f32c66c1f6ff45c7eb5c8f660394d381a1e2bd638fR1-R139)

**Unity Metadata Files:**

* Added corresponding `.meta` files for each material and folder to support Unity's asset management and referencing. [[1]](diffhunk://#diff-92044d592ed217f487ae5520c72a63b898409b833f46768113505c64b7ea6782R1-R8) [[2]](diffhunk://#diff-fbb67660c2c3c781c89e14eea681fe67a46ed6a0f0565fcf2d4c09a166f08608R1-R8) [[3]](diffhunk://#diff-e52a854b1941a2dce0661608c6c64800a638c95e6af712259ea2706a2274e98dR1-R8) [[4]](diffhunk://#diff-6d04427e9ceb901c62268699026ff5b42b6e2ecd5f317fa2901f90f6a79fd71bR1-R8) [[5]](diffhunk://#diff-6f8f2df545c39965b6306a6efd7c954f0b34624444af83685e1c3bc4e71c0622R1-R8)

These changes lay the groundwork for organizing and rendering car assets with custom materials in the Unity project.
This pull request updates the materials assigned to various mesh renderers in the `entrance_with_visitor_rooms.prefab` file. The main change is the replacement of the material with GUID `dff06ded3acfb4e4c901b78b0fdfda8b` by the material with GUID `0da42f37180c9924fb6cb0e71b03278e` for multiple mesh objects, and the addition of this material to the first slot of several mesh renderer components.

Material assignment updates:

* Changed the material in `m_Materials.Array.data[1]` from GUID `dff06ded3acfb4e4c901b78b0fdfda8b` to GUID `0da42f37180c9924fb6cb0e71b03278e` for multiple mesh renderer targets throughout `entrance_with_visitor_rooms.prefab`. [[1]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eL5947-R5963) [[2]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eL6409-R6425) [[3]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eL10043-R10083) [[4]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eL11899-R11947)

* Added the material with GUID `0da42f37180c9924fb6cb0e71b03278e` to `m_Materials.Array.data[0]` for several mesh renderer targets, including those with file IDs `6558207639728429531`, `4157103995261680203`, `1158315993814442110`, and `4611164815108111335`. [[1]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eR2040-R2043) [[2]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eR4148-R4151) [[3]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eR5044-R5047) [[4]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eR5308-R5311) [[5]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eR6752-R6755) [[6]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eR6840-R6851) [[7]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eR7210-R7213) [[8]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eR8088-R8091) [[9]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eR9878-R9881) [[10]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eR11412-R11415) [[11]](diffhunk://#diff-ff6df1f341696467299085a9933281696155a665fcb869f9890065881286256eR11676-R11679)

These changes ensure consistent material usage across the prefab and may affect the visual appearance of the entrance and visitor rooms.