### PR TITLE
Fix: Interaction through walls

### DIFF
--- a/Assets/Scripts/Player/Interaction/InteractWithObject.cs
+++ b/Assets/Scripts/Player/Interaction/InteractWithObject.cs
@@ -50,7 +50,9 @@ public class InteractWithObject : MonoBehaviour
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
     {
-        
+        hudCanvas.Hide();
+            
+        currentInteractable = null;
     }
 
     // Update is called once per frame
@@ -66,23 +68,28 @@ public class InteractWithObject : MonoBehaviour
         
         Debug.DrawRay(checkRay.origin, checkRay.direction, Color.red);
         
-        if (Physics.Raycast(checkRay, out RaycastHit hit, interactionDistance, interactionLayer))
+        if (Physics.Raycast(checkRay, out RaycastHit hit, interactionDistance))
         {
-            if (hit.collider.TryGetComponent(out IInteractable interactable))
+            if (hit.collider.gameObject.layer == LayerMask.NameToLayer("Interactable"))
             {
-                currentInteractable = interactable;
+                Collider targetCollider = hit.collider;
+                GameObject targetObject = targetCollider.gameObject;
                 
-                hudCanvas.Show(currentInteractable.InteractionPrompt);
-                
-                return;
+                if (targetCollider.TryGetComponent(out IInteractable interactable))
+                {
+                    currentInteractable = interactable;
+                    
+                    hudCanvas.Show(currentInteractable.InteractionPrompt);
+                    
+                    return;
+                }
             }
+            else
+            {
+                hudCanvas.Hide();
             
-        }
-        else
-        {
-            hudCanvas.Hide();
-            
-            currentInteractable = null;
+                currentInteractable = null;
+            }
         }
     }
     


### PR DESCRIPTION
This PR fixes a bug that let players interact through walls.

In Unity, Raycasts are not blocked by colliders that are not in the layer mask of the hit detection.
Thus it was possible to "see" interactables behind walls


closes #175 